### PR TITLE
feat(controller): add basic label based addon generation

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,8 @@ namespace: addon-discovery-system
 namePrefix: addon-discovery-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  discovery.addons.k8s.io/addon-discovery: ""
 
 bases:
 - ../crd

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: quay.io/njhale/addon-discovery
+  newTag: latest


### PR DESCRIPTION
Add basic logic for generating addons when component labels are observed.

Note, this doesn't cover:
- Preventing unauthorized users from adding components
- Verifying existing component labels were accepted by authorization mechanism
- Quick recreation of deleted addons when components still exist